### PR TITLE
Make build dependencies explicit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=65", "Cython>=3.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
 import os
-from distutils.core import setup
-from distutils.extension import Extension
 
 from Cython.Build import cythonize
-from Cython.Distutils import build_ext
+from setuptools import Extension, setup
 
 home = os.environ.get("HOME")
 source = os.environ.get(


### PR DESCRIPTION
Transparent switch from distutils (removed in Python 3.12) to setuptools, add pyproject.toml with build dependencies