### PR TITLE
Python wheel: fix macos action checkout

### DIFF
--- a/.github/workflows/build-wheel-macos.yml
+++ b/.github/workflows/build-wheel-macos.yml
@@ -41,8 +41,12 @@ jobs:
           ref: develop
           path: ci-utils
           token: ${{ secrets.GH_REPO_READ_TOKEN }}
-      - run: rm -rf proj && git clone --depth=1 --branch="${GITHUB_REF#refs/heads/}" https://github.com/$GITHUB_REPOSITORY proj
-      - run: cd proj && ./build_chain.sh
+      - uses: actions/checkout@v4
+        with:
+          path: proj
+      - run: |
+          cd proj
+          PYTHONPATH=$GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts ./build_chain.sh
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/build_chain.sh
+++ b/build_chain.sh
@@ -1,4 +1,3 @@
-#!/usr/bin/bash
 # (C) Copyright 2024- ECMWF.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0


### PR DESCRIPTION
A few more missing details. Tested by manual trigger, macos action for wheel publish now works