### PR TITLE
Feature/gridspec

### DIFF
--- a/src/_mir/_mir.pyx
+++ b/src/_mir/_mir.pyx
@@ -212,6 +212,11 @@ cdef class Grid:
             # opportunity to do something interesting
             raise
 
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Grid):
+            return NotImplemented
+        return self.spec_str == other.spec_str
+
     def to_latlons(self):
         cdef pair[vector[double], vector[double]] latlons = self._grid.to_latlons()
         return list(latlons.first), list(latlons.second)

--- a/src/_mir/_mir.pyx
+++ b/src/_mir/_mir.pyx
@@ -82,6 +82,18 @@ cdef class GridSpecInput(MIRInput):
     def __dealloc__(self):
         del self._input
 
+cdef class GriddefInput(MIRInput):
+    def __cinit__(self, string path):
+        self._input = new mir.GriddefInput(eckit.PathName(path))
+    def __dealloc__(self):
+        del self._input
+
+cdef class EmptyOutput(MIROutput):
+    def __cinit__(self):
+        self._output = new mir.EmptyOutput()
+    def __dealloc__(self):
+        del self._output
+
 cdef class GribMemoryOutput(MIROutput):
     def __cinit__(self, unsigned char[::1] buf):
         self._output = new mir.GribMemoryOutput(&buf[0], buf.nbytes)

--- a/src/_mir/_mir.pyx
+++ b/src/_mir/_mir.pyx
@@ -29,13 +29,13 @@ cdef class Args:
     cdef char** argv
 
     def __cinit__(self):
-        import sys 
+        import sys
 
         self.argc = len(sys.argv)
         self.argv = <char**> malloc(self.argc * sizeof(char*))
         for i, arg in enumerate(sys.argv):
             self.argv[i] = arg
-    
+
     def __dealloc__(self):
         free(self.argv)
 
@@ -73,6 +73,12 @@ cdef class GribFileOutput(MIROutput):
 cdef class GribMemoryInput(MIRInput):
     def __cinit__(self, const unsigned char[::1] data):
         self._input = new mir.GribMemoryInput(&data[0], data.nbytes)
+    def __dealloc__(self):
+        del self._input
+
+cdef class GridSpecInput(MIRInput):
+    def __cinit__(self, string gridspec):
+        self._input = new mir.GridSpecInput(gridspec)
     def __dealloc__(self):
         del self._input
 

--- a/src/_mir/_mir.pyx
+++ b/src/_mir/_mir.pyx
@@ -201,10 +201,16 @@ cdef class Grid:
 
     def __cinit__(self, spec:str=None, **kwargs):
         assert bool(spec) != bool(kwargs)
-        if kwargs:
-            from yaml import dump
-            spec = dump(kwargs, default_flow_style=True).strip()
-        self._grid = eckit_geo.GridFactory.make_from_string(spec.encode())
+
+        try:
+            if kwargs:
+                from yaml import dump
+                spec = dump(kwargs, default_flow_style=True).strip()
+            self._grid = eckit_geo.GridFactory.make_from_string(spec.encode())
+
+        except RuntimeError as e:
+            # opportunity to do something interesting
+            raise
 
     def to_latlons(self):
         cdef pair[vector[double], vector[double]] latlons = self._grid.to_latlons()

--- a/src/_mir/eckit_geo_defs.pxd
+++ b/src/_mir/eckit_geo_defs.pxd
@@ -33,4 +33,4 @@ cdef extern from "eckit/geo/Grid.h" namespace "eckit::geo":
 
     cdef cppclass GridFactory:
         @staticmethod
-        const Grid* make_from_string(const string)
+        const Grid* make_from_string(const string) except +

--- a/src/_mir/eckit_geo_defs.pxd
+++ b/src/_mir/eckit_geo_defs.pxd
@@ -1,0 +1,36 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+from libcpp.string cimport string
+from libcpp.utility cimport pair
+from libcpp.vector cimport vector
+
+cdef extern from "eckit/filesystem/PathName.h" namespace "eckit":
+    cdef cppclass PathName:
+        PathName(string)
+
+cdef extern from "eckit/geo/area/BoundingBox.h" namespace "eckit::geo::area":
+    cdef cppclass BoundingBox:
+        const double& north
+        const double& west
+        const double& south
+        const double& east
+
+cdef extern from "eckit/geo/Grid.h" namespace "eckit::geo":
+    cdef cppclass Grid:
+        pair[vector[double], vector[double]] to_latlons() const
+        string spec_str() const
+        string type() const
+        vector[size_t] shape() const
+        size_t size() const
+        const BoundingBox& boundingBox() const
+
+    cdef cppclass GridFactory:
+        @staticmethod
+        const Grid* make_from_string(const string)

--- a/src/_mir/mir_defs.pxd
+++ b/src/_mir/mir_defs.pxd
@@ -16,7 +16,7 @@ cdef extern from "mir/api/MIRJob.h" namespace "mir::api":
         MIRJob& set(string, int)
         MIRJob& set(string, double)
         MIRJob& set(string, double, double)
-        void execute(MIRInput, MIROutput)
+        void execute(MIRInput, MIROutput) except +
         void json(eckit.JSON&)
 
 cdef extern from "<sstream>" namespace "std" nogil:

--- a/src/_mir/mir_defs.pxd
+++ b/src/_mir/mir_defs.pxd
@@ -44,6 +44,10 @@ cdef extern from "mir/input/GridSpecInput.h" namespace "mir::input":
     cdef cppclass GridSpecInput(MIRInput):
         GridSpecInput(string)
 
+cdef extern from "mir/input/GriddefInput.h" namespace "mir::input":
+    cdef cppclass GriddefInput(MIRInput):
+        GriddefInput(eckit.PathName)
+
 cdef extern from "mir/output/MIROutput.h" namespace "mir::output":
     cdef cppclass MIROutput:
         pass
@@ -56,6 +60,10 @@ cdef extern from "mir/output/GribMemoryOutput.h" namespace "mir::output":
     cdef cppclass GribMemoryOutput(MIROutput):
         GribMemoryOutput(void*, size_t)
         size_t length()
+
+cdef extern from "mir/output/EmptyOutput.h" namespace "mir::output":
+    cdef cppclass EmptyOutput(MIROutput):
+        EmptyOutput()
 
 cdef extern from "mir/config/LibMir.h" namespace "mir":
     cdef cppclass LibMir:

--- a/src/_mir/mir_defs.pxd
+++ b/src/_mir/mir_defs.pxd
@@ -40,6 +40,10 @@ cdef extern from "mir/input/MultiDimensionalGribFileInput.h" namespace "mir::inp
     cdef cppclass MultiDimensionalGribFileInput(MIRInput):
         MultiDimensionalGribFileInput(eckit.PathName, size_t)
 
+cdef extern from "mir/input/GridSpecInput.h" namespace "mir::input":
+    cdef cppclass GridSpecInput(MIRInput):
+        GridSpecInput(string)
+
 cdef extern from "mir/output/MIROutput.h" namespace "mir::output":
     cdef cppclass MIROutput:
         pass

--- a/tests/test_gridspec.py
+++ b/tests/test_gridspec.py
@@ -1,0 +1,55 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from pathlib import Path
+
+import pytest
+from itertools import product
+
+
+GRIDSPECS = [
+    (dict(grid="1/1"), 360 * 181),
+    (dict(grid="H2", ordering="nested"), 12 * 2 * 2),
+    (dict(grid=[2, 2]), 180 * 91),
+    ("{grid: 3/3}", 120 * 61),
+    (dict(grid="o2"), sum([20, 24, 24, 20])),
+]
+
+
+def _gridspec_as_string(g):
+    from yaml import dump
+
+    return g if isinstance(g, str) else dump(g, default_flow_style=True).strip()
+
+
+@pytest.mark.parametrize(
+    "GSa, Na, GSb, Nb",
+    [
+        (_gridspec_as_string(a[0]), int(a[1]), _gridspec_as_string(b[0]), int(b[1]))
+        for a, b in product(GRIDSPECS, GRIDSPECS)
+        if a != b
+    ],
+)
+def test_mir(tmp_path, GSa, Na, GSb, Nb):
+    import mir
+
+    mat = Path(tmp_path) / "matrix.mat"
+    assert not mat.exists()
+
+    job = mir.Job()
+    job.set("grid", GSb)
+    job.set("interpolation-matrix", str(mat))
+
+    job.execute(mir.GridSpecInput(GSa), mir.EmptyOutput())
+
+    # FIXME also check matrix size
+    assert mat.exists()
+    assert Na == len(mir.Grid(GSa))
+    assert Nb == len(mir.Grid(GSb))
+
+    mat.unlink()


### PR DESCRIPTION
I'm drawing a lot of people in for feedback, feel free to participate with any feedback (that's the point of the PR).

I've extended the mir-python interface to include some limited eckit::geo::Grid functionality (there's a lot more in there, but we start small), so we have a starting point for a future earthkit interface. This would be important for ek's regrid, geo, and maybe other modules.

There's no intention to keep this as-is, even in Cython or not, just to explore the interface. I intend to merge this in as mir-python is still private for the time being, but once public we might want to remove this.

This gives you a (mostly) exception-safe interface to create a Grid, internaly polymorphic. To instantiate a mir.Grid do either, not both:
- g=mir.Grid(spec) # as a yaml string like "{grid:1/1}"
- g=mir.Grid(grid="H2") # as dict/kwargs, other keywords are available but let's stick to this (like "area" but incomplete)

This is possible:
>>> for lat,lon in zip(*mir.Grid(grid="h2").to_latlons()):
...   print(lat,lon)
... # correct stuff
>>> for lat,lon in zip(*mir.Grid(grid="h2",ordering="nested").to_latlons()):
...   print(lat,lon)
... # correct stuff
>>> for lat,lon in zip(*mir.Grid(grid="h2",ordering="xnested").to_latlons()):
...   print(lat,lon)
RuntimeError: SpecError: [HEALPix: supported ordering: ring, nested (Only orderingConvention are supported)], in  (...)

If you call g.spec it is canonical, that is
>>> mir.Grid(pl=[20,24,24,20]) == mir.Grid(grid="o2") == mir.Grid("{grid: o2}")
True

Note, the spec isn't finished, the area and projection (incl. rotation) is not correctly output so some of the logic is confused in those cases. Improvements here are exclusive to improve eckit::geo.

This interface can be combined with eccodes python interface that has been built with both eckit::geo and has the special key accessor "gridSpec" (in boot.def) built in.

Example use:

>>> import mir
>>> g=mir.Grid(grid="eORCA1_T")
Downloading 'https://get.ecmwf.int/repository/atlas/grids/orca/v0/eORCA1_T.atlas' to '/Users/mapm/.local/share/eckit/geo/grid/orca/eORCA1-814b2b254e380ac6059e3efc3f876acf.ek'...
Read  rate: 1.28737 Mbytes per second
Write rate: 1.61738 Gbytes per second
Save into: 0.758971 second elapsed, 0.039196 second cpu
Download of 861.54 Kbytes took 1.13365s.
>>> len(g)
120184
>>> g.shape
[362, 332]
>>> g.spec
{'grid': 'eORCA1_T', 'uid': 'ba65665a9e68d1a8fa0352ecfcf8e496'}
>>> g=mir.Grid(grid="eORCA1_F")
Downloading 'https://get.ecmwf.int/repository/atlas/grids/orca/v0/eORCA1_F.atlas' to '/Users/mapm/.local/share/eckit/geo/grid/orca/eORCA1-8bd8ee0cd6c04d0f3dc59aa30cb38446.ek'...
Read  rate: 1.94052 Mbytes per second
Write rate: 618.45 Mbytes per second
Save into: 0.537579 second elapsed, 0.037242 second cpu
Download of 863.812 Kbytes took 0.755487s.
>>> g.spec
{'grid': 'eORCA1_F', 'uid': '3c6d95561710c6f39b394809ff6c588c'}
>>> g=mir.Grid(grid="eORCA1_T")
>>> for lat, lon in zip(*g.to_latlons()):
...     print(lat, lon)
... 
-84.21070904403568 72.49999999999818
-84.21070904403568 73.49999999999955
-84.21070904403568 74.49999999999955
... 
>>> 
>>> g=mir.Grid(pl=[20,24,24,20])
>>> g.bounding_box()
(90.0, 0.0, -90.0, 360.0)
>>> for lat, lon in zip(*g.to_latlons()):
...     print(lat,lon)
... 
59.44440828916676 0.0
59.44440828916676 18.0
59.44440828916676 36.0
... 
...
>>> g=mir.Grid(pl=[20,24,24,20],area=[45,0,0,45])
>>> for lat, lon in zip(*g.to_latlons()):
...     print(lat,lon)
... 
19.8757191474409 0.0
19.8757191474409 18.0
19.8757191474409 36.0
... 
>>> g=mir.Grid(grid="o2", area=[45,0,0,45.])
>>> g.spec     # NOTE THAT THIS RESULT IS WRONG, "areaSpec" needs work
{'grid': 'O2'}
>>> for lat,lon in zip(*g.to_latlons()):
...   print(lat,lon)
... 
19.8757191474409 0.0
19.8757191474409 18.0
19.8757191474409 36.0
>>> len(g)
3

