### PR TITLE
Fix chain wheel build script

### DIFF
--- a/build_chain.sh
+++ b/build_chain.sh
@@ -31,7 +31,8 @@ else
 fi
 
 # mir-python prereqs
-uv pip install $EXTRA_PIP eccodeslib eckitlib mirlib
+# TODO get these from pyproject...
+uv pip install --prerelease=allow $EXTRA_PIP eccodeslib eckitlib mirlib numpy
 PRF=".venv/lib/python3.11/site-packages"
 if [ "$(uname)" == "Darwin" ] ; then L="lib" ; else L="lib64" ; fi
 export MIR_LIB_DIR="$PRF/eckitlib/$L:$PRF/eccodeslib/$L:$PRF/mirlib/$L"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,12 @@
 
 
 [build-system]
-requires = ["setuptools>=65", "Cython>=3.0", "wheel"]
+requires = ["setuptools>=65", "Cython>=3.0", "wheel", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "mir"
-version = "0.3.0"
+name = "mir-python"
+version = "0.3.1"
 description = "Don't use this"
 requires-python=">=3.9"
 authors = [
@@ -32,7 +32,7 @@ classifiers=[
 	"Operating System :: MacOS",
 	"Topic :: Scientific/Engineering",
 ]
-dependencies = ["findlibs", "mirlib"]
+dependencies = ["findlibs", "mirlib", "numpy"]
 
 
 [tool.setuptools]


### PR DESCRIPTION
1/ Adding `numpy` to dependencies of setup (not sure if we want to build the wheel with it or without... so including for simplicity)
2/ Changing the name to `mir-python`, so that it can be pypi uploaded. Note it affects the wheel only, not the module -- so we still `import mir`
3/ Fixing `--prerelease=allow` for pip installs, until things stabilize on the pypi front
4/ Bumping version to `0.3.1`. I don't have the buildnumber-bumper in place yet for this case of collisions, I'll probably integrate it later