### PR TITLE
ci: migrate ecmwf-actions references to ecmwf

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,7 +17,7 @@ jobs:
   #   It will correctly handle addition of any new and removal of existing Git objects.
   sync:
     name: sync
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/sync.yml@v2
+    uses: ecmwf/reusable-workflows/.github/workflows/sync.yml@v2
     secrets:
       target_repository: mir/mir-python
       target_username: ClonedDuck


### PR DESCRIPTION
## Summary
The `ecmwf-actions` GitHub organization has been merged into `ecmwf`.
This PR updates workflow `uses:` directives from `ecmwf-actions/` to `ecmwf/`.

No functional changes - the actions are identical, just relocated.

---
*This PR was created automatically.*
